### PR TITLE
Add XXX to template for GNU mktemp compatibility

### DIFF
--- a/gifcap
+++ b/gifcap
@@ -58,7 +58,7 @@ function require() {
 # The file will be created inside of TMPDIR.
 function better_mktemp() {
   ARG="$1"
-  FILENAME=${ARG%.*}
+  FILENAME=${ARG%.*}XXX
   EXT=${ARG##*.}
 
   FILE=`mktemp -t ${FILENAME} || exit 1`


### PR DESCRIPTION
On my Mac with Homebrew `coreutils` installed, the script fails when calling `mktemp` because the GNU version requires the XXX characters in its template. From its manpage:

> Create  a  temporary file or directory, safely, and print its name.  TEMPLATE must contain at least 3 consecutive 'X's in last component.

However, the OS X version of `mktemp` seems to treat the `-t` argument as a *prefix*. See https://unix.stackexchange.com/questions/30091/fix-or-alternative-for-mktemp-in-os-x for more information.

In any case, I think appending `XXX` to the end of the argument, allows compatibility with both GNU and OS X versions of `mktemp`